### PR TITLE
Support Odd `NUM_TRACE_AND_ANALYZER_INST` parameter

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -1,7 +1,7 @@
 packages:
   axi:
-    revision: 78831b6feba265d5ee2683bbf42b4150f8a35c43
-    version: 0.39.8
+    revision: a256a3b86394fedf19e361047fccfdd7f6ef83e4
+    version: 0.39.9
     source:
       Git: https://github.com/pulp-platform/axi.git
     dependencies:
@@ -9,8 +9,8 @@ packages:
     - common_verification
     - tech_cells_generic
   common_cells:
-    revision: 9afda9abb565971649c2aa0985639c096f351171
-    version: 1.38.0
+    revision: 9ca8a7655f741e7dd5736669a20a301325194c28
+    version: 1.39.0
     source:
       Git: https://github.com/pulp-platform/common_cells.git
     dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Fixed 
+
+### Changed
+
+### Removed
+
+## [0.2.2] - 2026-05-27
+
+### Added
+
 - Added new section under [README.md](README.md) to reference integration guide and architecture documentation 
 
 ### Fixed 
 
 - Fixed DC elaboration issue in dfd_cross_connect.sv with loop var i
-
-### Changed
-
-### Removed
+- Fixed PARAMETER NUM_TRACE_AND_ANALYZER_INST to allow support for ODD values without throwing error on EDA toosl (caught in [Issue #21](https://github.com/tenstorrent/tt-dfd/issues/21))
 
 ## [0.2.1] - 2025-11-26
 

--- a/dv/dfd/dfd_tb.sv
+++ b/dv/dfd/dfd_tb.sv
@@ -16,7 +16,7 @@ module dfd_tb
   import dfd_CL_axi_pkg::*;
 #(
     parameter TEST = 1,
-    parameter NUM_TRACE_AND_ANALYZER_INST = 2
+    parameter NUM_TRACE_AND_ANALYZER_INST = 5
 ) ();
 
   // Clock and reset

--- a/rtl/dfd/dfd_top.sv
+++ b/rtl/dfd/dfd_top.sv
@@ -25,8 +25,8 @@ module dfd_top
   import dfd_tn_pkg::*;
   import dfd_CL_axi_pkg::*;
 #(
-    parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1,
-    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : NUM_TRACE_AND_ANALYZER_INST,
+    parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1, 
+    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : ((NUM_TRACE_AND_ANALYZER_INST + 1) & ~1), // Even Number
     parameter bit NTRACE_SUPPORT = 1,  /* @@ KEEP - (NTRACE) {\tparameter NTRACE_SUPPORT = 0,} @@ */
     parameter bit DST_SUPPORT = 1,  /* @@ KEEP - (DST) {\tparameter DST_SUPPORT = 0,} @@ */
     parameter bit CLA_SUPPORT = 1,  /* @@ KEEP - (CLA) {\tparameter CLA_SUPPORT = 0,} @@ */
@@ -511,7 +511,7 @@ module dfd_top
   // Trace Top (Contains Trace Network -> Trace Funnel -> Trace Mem)
   if ((DST_SUPPORT == 1) || (NTRACE_SUPPORT == 1)) begin : trace_top_gen_blk
     dfd_trace_top #(
-        .NUM_CORES(TNIF_CONNECTIONS),  // Minimum 2 TNIFs
+        .NUM_CORES(TNIF_CONNECTIONS),  // Even Number 
         .NUM_ACTIVE_CORES(NUM_TRACE_AND_ANALYZER_INST),
         .BASE_ADDR(BASE_ADDR[DFD_APB_ADDR_WIDTH-1:0]),
         .DATA_WIDTH_IN_BYTES(DATA_WIDTH_IN_BYTES),

--- a/rtl/gen_files/dfd_top_cla.sv
+++ b/rtl/gen_files/dfd_top_cla.sv
@@ -26,7 +26,7 @@ module dfd_top_cla
   import dfd_CL_axi_pkg::*;
 #(
     parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1,
-    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : NUM_TRACE_AND_ANALYZER_INST,
+    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : ((NUM_TRACE_AND_ANALYZER_INST + 1) & ~1), // Even Number
 	parameter NTRACE_SUPPORT = 0,
 	parameter DST_SUPPORT = 0,
     parameter bit CLA_SUPPORT = 1,
@@ -426,7 +426,7 @@ module dfd_top_cla
   // Trace Top (Contains Trace Network -> Trace Funnel -> Trace Mem)
   if ((DST_SUPPORT == 1) || (NTRACE_SUPPORT == 1)) begin : trace_top_gen_blk
     dfd_trace_top #(
-        .NUM_CORES(TNIF_CONNECTIONS),  // Minimum 2 TNIFs
+        .NUM_CORES(TNIF_CONNECTIONS),  // Even Number
         .NUM_ACTIVE_CORES(NUM_TRACE_AND_ANALYZER_INST),
         .BASE_ADDR(BASE_ADDR[DFD_APB_ADDR_WIDTH-1:0]),
         .DATA_WIDTH_IN_BYTES(DATA_WIDTH_IN_BYTES),

--- a/rtl/gen_files/dfd_top_cla_dst.sv
+++ b/rtl/gen_files/dfd_top_cla_dst.sv
@@ -26,7 +26,7 @@ module dfd_top_cla_dst
   import dfd_CL_axi_pkg::*;
 #(
     parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1,
-    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : NUM_TRACE_AND_ANALYZER_INST,
+    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : ((NUM_TRACE_AND_ANALYZER_INST + 1) & ~1), // Even Number
 	parameter NTRACE_SUPPORT = 0,
     parameter bit DST_SUPPORT = 1,
     parameter bit CLA_SUPPORT = 1,
@@ -432,7 +432,7 @@ module dfd_top_cla_dst
   // Trace Top (Contains Trace Network -> Trace Funnel -> Trace Mem)
   if ((DST_SUPPORT == 1) || (NTRACE_SUPPORT == 1)) begin : trace_top_gen_blk
     dfd_trace_top #(
-        .NUM_CORES(TNIF_CONNECTIONS),  // Minimum 2 TNIFs
+        .NUM_CORES(TNIF_CONNECTIONS),  // Even Number
         .NUM_ACTIVE_CORES(NUM_TRACE_AND_ANALYZER_INST),
         .BASE_ADDR(BASE_ADDR[DFD_APB_ADDR_WIDTH-1:0]),
         .DATA_WIDTH_IN_BYTES(DATA_WIDTH_IN_BYTES),

--- a/rtl/gen_files/dfd_top_cla_dst_mmr.sv
+++ b/rtl/gen_files/dfd_top_cla_dst_mmr.sv
@@ -26,7 +26,7 @@ module dfd_top_cla_dst_mmr
   import dfd_CL_axi_pkg::*;
 #(
     parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1,
-    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : NUM_TRACE_AND_ANALYZER_INST,
+    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : ((NUM_TRACE_AND_ANALYZER_INST + 1) & ~1), // Even Number
 	parameter NTRACE_SUPPORT = 0,
     parameter bit DST_SUPPORT = 1,
     parameter bit CLA_SUPPORT = 1,
@@ -431,7 +431,7 @@ module dfd_top_cla_dst_mmr
   // Trace Top (Contains Trace Network -> Trace Funnel -> Trace Mem)
   if ((DST_SUPPORT == 1) || (NTRACE_SUPPORT == 1)) begin : trace_top_gen_blk
     dfd_trace_top #(
-        .NUM_CORES(TNIF_CONNECTIONS),  // Minimum 2 TNIFs
+        .NUM_CORES(TNIF_CONNECTIONS),  // Even Number
         .NUM_ACTIVE_CORES(NUM_TRACE_AND_ANALYZER_INST),
         .BASE_ADDR(BASE_ADDR[DFD_APB_ADDR_WIDTH-1:0]),
         .DATA_WIDTH_IN_BYTES(DATA_WIDTH_IN_BYTES),

--- a/rtl/gen_files/dfd_top_cla_dst_ntrace.sv
+++ b/rtl/gen_files/dfd_top_cla_dst_ntrace.sv
@@ -26,7 +26,7 @@ module dfd_top_cla_dst_ntrace
   import dfd_CL_axi_pkg::*;
 #(
     parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1,
-    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : NUM_TRACE_AND_ANALYZER_INST,
+    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : ((NUM_TRACE_AND_ANALYZER_INST + 1) & ~1), // Even Number
     parameter bit NTRACE_SUPPORT = 1,
     parameter bit DST_SUPPORT = 1,
     parameter bit CLA_SUPPORT = 1,
@@ -434,7 +434,7 @@ module dfd_top_cla_dst_ntrace
   // Trace Top (Contains Trace Network -> Trace Funnel -> Trace Mem)
   if ((DST_SUPPORT == 1) || (NTRACE_SUPPORT == 1)) begin : trace_top_gen_blk
     dfd_trace_top #(
-        .NUM_CORES(TNIF_CONNECTIONS),  // Minimum 2 TNIFs
+        .NUM_CORES(TNIF_CONNECTIONS),  // Even Number
         .NUM_ACTIVE_CORES(NUM_TRACE_AND_ANALYZER_INST),
         .BASE_ADDR(BASE_ADDR[DFD_APB_ADDR_WIDTH-1:0]),
         .DATA_WIDTH_IN_BYTES(DATA_WIDTH_IN_BYTES),

--- a/rtl/gen_files/dfd_top_cla_dst_ntrace_mmr.sv
+++ b/rtl/gen_files/dfd_top_cla_dst_ntrace_mmr.sv
@@ -26,7 +26,7 @@ module dfd_top_cla_dst_ntrace_mmr
   import dfd_CL_axi_pkg::*;
 #(
     parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1,
-    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : NUM_TRACE_AND_ANALYZER_INST,
+    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : ((NUM_TRACE_AND_ANALYZER_INST + 1) & ~1), // Even Number
     parameter bit NTRACE_SUPPORT = 1,
     parameter bit DST_SUPPORT = 1,
     parameter bit CLA_SUPPORT = 1,
@@ -433,7 +433,7 @@ module dfd_top_cla_dst_ntrace_mmr
   // Trace Top (Contains Trace Network -> Trace Funnel -> Trace Mem)
   if ((DST_SUPPORT == 1) || (NTRACE_SUPPORT == 1)) begin : trace_top_gen_blk
     dfd_trace_top #(
-        .NUM_CORES(TNIF_CONNECTIONS),  // Minimum 2 TNIFs
+        .NUM_CORES(TNIF_CONNECTIONS),  // Even Number
         .NUM_ACTIVE_CORES(NUM_TRACE_AND_ANALYZER_INST),
         .BASE_ADDR(BASE_ADDR[DFD_APB_ADDR_WIDTH-1:0]),
         .DATA_WIDTH_IN_BYTES(DATA_WIDTH_IN_BYTES),

--- a/rtl/gen_files/dfd_top_cla_mmr.sv
+++ b/rtl/gen_files/dfd_top_cla_mmr.sv
@@ -26,7 +26,7 @@ module dfd_top_cla_mmr
   import dfd_CL_axi_pkg::*;
 #(
     parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1,
-    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : NUM_TRACE_AND_ANALYZER_INST,
+    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : ((NUM_TRACE_AND_ANALYZER_INST + 1) & ~1), // Even Number
 	parameter NTRACE_SUPPORT = 0,
 	parameter DST_SUPPORT = 0,
     parameter bit CLA_SUPPORT = 1,
@@ -425,7 +425,7 @@ module dfd_top_cla_mmr
   // Trace Top (Contains Trace Network -> Trace Funnel -> Trace Mem)
   if ((DST_SUPPORT == 1) || (NTRACE_SUPPORT == 1)) begin : trace_top_gen_blk
     dfd_trace_top #(
-        .NUM_CORES(TNIF_CONNECTIONS),  // Minimum 2 TNIFs
+        .NUM_CORES(TNIF_CONNECTIONS),  // Even Number
         .NUM_ACTIVE_CORES(NUM_TRACE_AND_ANALYZER_INST),
         .BASE_ADDR(BASE_ADDR[DFD_APB_ADDR_WIDTH-1:0]),
         .DATA_WIDTH_IN_BYTES(DATA_WIDTH_IN_BYTES),

--- a/rtl/gen_files/dfd_top_cla_ntrace.sv
+++ b/rtl/gen_files/dfd_top_cla_ntrace.sv
@@ -26,7 +26,7 @@ module dfd_top_cla_ntrace
   import dfd_CL_axi_pkg::*;
 #(
     parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1,
-    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : NUM_TRACE_AND_ANALYZER_INST,
+    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : ((NUM_TRACE_AND_ANALYZER_INST + 1) & ~1), // Even Number
     parameter bit NTRACE_SUPPORT = 1,
 	parameter DST_SUPPORT = 0,
     parameter bit CLA_SUPPORT = 1,
@@ -431,7 +431,7 @@ module dfd_top_cla_ntrace
   // Trace Top (Contains Trace Network -> Trace Funnel -> Trace Mem)
   if ((DST_SUPPORT == 1) || (NTRACE_SUPPORT == 1)) begin : trace_top_gen_blk
     dfd_trace_top #(
-        .NUM_CORES(TNIF_CONNECTIONS),  // Minimum 2 TNIFs
+        .NUM_CORES(TNIF_CONNECTIONS),  // Even Number
         .NUM_ACTIVE_CORES(NUM_TRACE_AND_ANALYZER_INST),
         .BASE_ADDR(BASE_ADDR[DFD_APB_ADDR_WIDTH-1:0]),
         .DATA_WIDTH_IN_BYTES(DATA_WIDTH_IN_BYTES),

--- a/rtl/gen_files/dfd_top_cla_ntrace_mmr.sv
+++ b/rtl/gen_files/dfd_top_cla_ntrace_mmr.sv
@@ -26,7 +26,7 @@ module dfd_top_cla_ntrace_mmr
   import dfd_CL_axi_pkg::*;
 #(
     parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1,
-    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : NUM_TRACE_AND_ANALYZER_INST,
+    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : ((NUM_TRACE_AND_ANALYZER_INST + 1) & ~1), // Even Number
     parameter bit NTRACE_SUPPORT = 1,
 	parameter DST_SUPPORT = 0,
     parameter bit CLA_SUPPORT = 1,
@@ -430,7 +430,7 @@ module dfd_top_cla_ntrace_mmr
   // Trace Top (Contains Trace Network -> Trace Funnel -> Trace Mem)
   if ((DST_SUPPORT == 1) || (NTRACE_SUPPORT == 1)) begin : trace_top_gen_blk
     dfd_trace_top #(
-        .NUM_CORES(TNIF_CONNECTIONS),  // Minimum 2 TNIFs
+        .NUM_CORES(TNIF_CONNECTIONS),  // Even Number
         .NUM_ACTIVE_CORES(NUM_TRACE_AND_ANALYZER_INST),
         .BASE_ADDR(BASE_ADDR[DFD_APB_ADDR_WIDTH-1:0]),
         .DATA_WIDTH_IN_BYTES(DATA_WIDTH_IN_BYTES),

--- a/rtl/gen_files/dfd_top_dst.sv
+++ b/rtl/gen_files/dfd_top_dst.sv
@@ -26,7 +26,7 @@ module dfd_top_dst
   import dfd_CL_axi_pkg::*;
 #(
     parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1,
-    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : NUM_TRACE_AND_ANALYZER_INST,
+    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : ((NUM_TRACE_AND_ANALYZER_INST + 1) & ~1), // Even Number
 	parameter NTRACE_SUPPORT = 0,
     parameter bit DST_SUPPORT = 1,
 	parameter CLA_SUPPORT = 0,
@@ -433,7 +433,7 @@ module dfd_top_dst
   // Trace Top (Contains Trace Network -> Trace Funnel -> Trace Mem)
   if ((DST_SUPPORT == 1) || (NTRACE_SUPPORT == 1)) begin : trace_top_gen_blk
     dfd_trace_top #(
-        .NUM_CORES(TNIF_CONNECTIONS),  // Minimum 2 TNIFs
+        .NUM_CORES(TNIF_CONNECTIONS),  // Even Number
         .NUM_ACTIVE_CORES(NUM_TRACE_AND_ANALYZER_INST),
         .BASE_ADDR(BASE_ADDR[DFD_APB_ADDR_WIDTH-1:0]),
         .DATA_WIDTH_IN_BYTES(DATA_WIDTH_IN_BYTES),

--- a/rtl/gen_files/dfd_top_dst_mmr.sv
+++ b/rtl/gen_files/dfd_top_dst_mmr.sv
@@ -26,7 +26,7 @@ module dfd_top_dst_mmr
   import dfd_CL_axi_pkg::*;
 #(
     parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1,
-    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : NUM_TRACE_AND_ANALYZER_INST,
+    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : ((NUM_TRACE_AND_ANALYZER_INST + 1) & ~1), // Even Number
 	parameter NTRACE_SUPPORT = 0,
     parameter bit DST_SUPPORT = 1,
 	parameter CLA_SUPPORT = 0,
@@ -432,7 +432,7 @@ module dfd_top_dst_mmr
   // Trace Top (Contains Trace Network -> Trace Funnel -> Trace Mem)
   if ((DST_SUPPORT == 1) || (NTRACE_SUPPORT == 1)) begin : trace_top_gen_blk
     dfd_trace_top #(
-        .NUM_CORES(TNIF_CONNECTIONS),  // Minimum 2 TNIFs
+        .NUM_CORES(TNIF_CONNECTIONS),  // Even Number
         .NUM_ACTIVE_CORES(NUM_TRACE_AND_ANALYZER_INST),
         .BASE_ADDR(BASE_ADDR[DFD_APB_ADDR_WIDTH-1:0]),
         .DATA_WIDTH_IN_BYTES(DATA_WIDTH_IN_BYTES),

--- a/rtl/gen_files/dfd_top_dst_ntrace.sv
+++ b/rtl/gen_files/dfd_top_dst_ntrace.sv
@@ -26,7 +26,7 @@ module dfd_top_dst_ntrace
   import dfd_CL_axi_pkg::*;
 #(
     parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1,
-    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : NUM_TRACE_AND_ANALYZER_INST,
+    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : ((NUM_TRACE_AND_ANALYZER_INST + 1) & ~1), // Even Number
     parameter bit NTRACE_SUPPORT = 1,
     parameter bit DST_SUPPORT = 1,
 	parameter CLA_SUPPORT = 0,
@@ -435,7 +435,7 @@ module dfd_top_dst_ntrace
   // Trace Top (Contains Trace Network -> Trace Funnel -> Trace Mem)
   if ((DST_SUPPORT == 1) || (NTRACE_SUPPORT == 1)) begin : trace_top_gen_blk
     dfd_trace_top #(
-        .NUM_CORES(TNIF_CONNECTIONS),  // Minimum 2 TNIFs
+        .NUM_CORES(TNIF_CONNECTIONS),  // Even Number
         .NUM_ACTIVE_CORES(NUM_TRACE_AND_ANALYZER_INST),
         .BASE_ADDR(BASE_ADDR[DFD_APB_ADDR_WIDTH-1:0]),
         .DATA_WIDTH_IN_BYTES(DATA_WIDTH_IN_BYTES),

--- a/rtl/gen_files/dfd_top_dst_ntrace_mmr.sv
+++ b/rtl/gen_files/dfd_top_dst_ntrace_mmr.sv
@@ -26,7 +26,7 @@ module dfd_top_dst_ntrace_mmr
   import dfd_CL_axi_pkg::*;
 #(
     parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1,
-    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : NUM_TRACE_AND_ANALYZER_INST,
+    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : ((NUM_TRACE_AND_ANALYZER_INST + 1) & ~1), // Even Number
     parameter bit NTRACE_SUPPORT = 1,
     parameter bit DST_SUPPORT = 1,
 	parameter CLA_SUPPORT = 0,
@@ -434,7 +434,7 @@ module dfd_top_dst_ntrace_mmr
   // Trace Top (Contains Trace Network -> Trace Funnel -> Trace Mem)
   if ((DST_SUPPORT == 1) || (NTRACE_SUPPORT == 1)) begin : trace_top_gen_blk
     dfd_trace_top #(
-        .NUM_CORES(TNIF_CONNECTIONS),  // Minimum 2 TNIFs
+        .NUM_CORES(TNIF_CONNECTIONS),  // Even Number
         .NUM_ACTIVE_CORES(NUM_TRACE_AND_ANALYZER_INST),
         .BASE_ADDR(BASE_ADDR[DFD_APB_ADDR_WIDTH-1:0]),
         .DATA_WIDTH_IN_BYTES(DATA_WIDTH_IN_BYTES),

--- a/rtl/gen_files/dfd_top_mmr.sv
+++ b/rtl/gen_files/dfd_top_mmr.sv
@@ -26,7 +26,7 @@ module dfd_top_mmr
   import dfd_CL_axi_pkg::*;
 #(
     parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1,
-    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : NUM_TRACE_AND_ANALYZER_INST,
+    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : ((NUM_TRACE_AND_ANALYZER_INST + 1) & ~1), // Even Number
 	parameter NTRACE_SUPPORT = 0,
 	parameter DST_SUPPORT = 0,
 	parameter CLA_SUPPORT = 0,
@@ -412,7 +412,7 @@ module dfd_top_mmr
   // Trace Top (Contains Trace Network -> Trace Funnel -> Trace Mem)
   if ((DST_SUPPORT == 1) || (NTRACE_SUPPORT == 1)) begin : trace_top_gen_blk
     dfd_trace_top #(
-        .NUM_CORES(TNIF_CONNECTIONS),  // Minimum 2 TNIFs
+        .NUM_CORES(TNIF_CONNECTIONS),  // Even Number
         .NUM_ACTIVE_CORES(NUM_TRACE_AND_ANALYZER_INST),
         .BASE_ADDR(BASE_ADDR[DFD_APB_ADDR_WIDTH-1:0]),
         .DATA_WIDTH_IN_BYTES(DATA_WIDTH_IN_BYTES),

--- a/rtl/gen_files/dfd_top_ntrace.sv
+++ b/rtl/gen_files/dfd_top_ntrace.sv
@@ -26,7 +26,7 @@ module dfd_top_ntrace
   import dfd_CL_axi_pkg::*;
 #(
     parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1,
-    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : NUM_TRACE_AND_ANALYZER_INST,
+    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : ((NUM_TRACE_AND_ANALYZER_INST + 1) & ~1), // Even Number
     parameter bit NTRACE_SUPPORT = 1,
 	parameter DST_SUPPORT = 0,
 	parameter CLA_SUPPORT = 0,
@@ -418,7 +418,7 @@ module dfd_top_ntrace
   // Trace Top (Contains Trace Network -> Trace Funnel -> Trace Mem)
   if ((DST_SUPPORT == 1) || (NTRACE_SUPPORT == 1)) begin : trace_top_gen_blk
     dfd_trace_top #(
-        .NUM_CORES(TNIF_CONNECTIONS),  // Minimum 2 TNIFs
+        .NUM_CORES(TNIF_CONNECTIONS),  // Even Number
         .NUM_ACTIVE_CORES(NUM_TRACE_AND_ANALYZER_INST),
         .BASE_ADDR(BASE_ADDR[DFD_APB_ADDR_WIDTH-1:0]),
         .DATA_WIDTH_IN_BYTES(DATA_WIDTH_IN_BYTES),

--- a/rtl/gen_files/dfd_top_ntrace_mmr.sv
+++ b/rtl/gen_files/dfd_top_ntrace_mmr.sv
@@ -26,7 +26,7 @@ module dfd_top_ntrace_mmr
   import dfd_CL_axi_pkg::*;
 #(
     parameter int unsigned NUM_TRACE_AND_ANALYZER_INST = 1,
-    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : NUM_TRACE_AND_ANALYZER_INST,
+    localparam int unsigned TNIF_CONNECTIONS = (NUM_TRACE_AND_ANALYZER_INST <= 1) ? 2 : ((NUM_TRACE_AND_ANALYZER_INST + 1) & ~1), // Even Number
     parameter bit NTRACE_SUPPORT = 1,
 	parameter DST_SUPPORT = 0,
 	parameter CLA_SUPPORT = 0,
@@ -417,7 +417,7 @@ module dfd_top_ntrace_mmr
   // Trace Top (Contains Trace Network -> Trace Funnel -> Trace Mem)
   if ((DST_SUPPORT == 1) || (NTRACE_SUPPORT == 1)) begin : trace_top_gen_blk
     dfd_trace_top #(
-        .NUM_CORES(TNIF_CONNECTIONS),  // Minimum 2 TNIFs
+        .NUM_CORES(TNIF_CONNECTIONS),  // Even Number
         .NUM_ACTIVE_CORES(NUM_TRACE_AND_ANALYZER_INST),
         .BASE_ADDR(BASE_ADDR[DFD_APB_ADDR_WIDTH-1:0]),
         .DATA_WIDTH_IN_BYTES(DATA_WIDTH_IN_BYTES),


### PR DESCRIPTION
For Issue #21 

Update TNIF_CONNECTIONS to be ceiling even number. This will ensure "virtual" inputs are generated and no more complaints on the missing inputs. 